### PR TITLE
feat: Add tuning widget and local storage persistence

### DIFF
--- a/src/com/Controls/Main.js
+++ b/src/com/Controls/Main.js
@@ -4,6 +4,7 @@ import Notes from './Notes'
 import Octave from './Octave'
 import Position from './Position'
 import Voice from './Voice'
+import Tuning from './Tuning';
 
 
 export default function Controls() {
@@ -23,6 +24,8 @@ export default function Controls() {
     
     <Octave />
     
+    <Tuning />
+
     {/* <pre>{JSON.stringify(state,null,2)}</pre> */}
   </div>
 }

--- a/src/com/Controls/Tuning.js
+++ b/src/com/Controls/Tuning.js
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { useGuitar } from '../../../guitarContext';
+import { notes } from '../../../lib/constants';
+// Assuming noteIndex and indexNote might not be strictly needed if parsing/constructing manually
+// but will include them for now as per instructions.
+import { noteIndex, indexNote } from '../../../lib/helpers';
+
+const OCTAVE_RANGE = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+
+function Tuning() {
+  const { tuning, setTuning } = useGuitar();
+
+  if (!tuning) {
+    // Handle case where tuning might not be available yet, though context setup should prevent this.
+    return <div>Loading tuning...</div>;
+  }
+
+  const handleNoteChange = (stringIndex, newPitch) => {
+    const oldNote = tuning[stringIndex];
+    const oldOctave = oldNote.slice(-1);
+    const newTune = [...tuning];
+    newTune[stringIndex] = newPitch + oldOctave;
+    setTuning(newTune);
+  };
+
+  const handleOctaveChange = (stringIndex, newOctave) => {
+    const oldNote = tuning[stringIndex];
+    const oldPitch = oldNote.slice(0, -1);
+    const newTune = [...tuning];
+    newTune[stringIndex] = oldPitch + newOctave;
+    setTuning(newTune);
+  };
+
+  return (
+    <div className="tuning-widget">
+      <h3>Tuning</h3>
+      {tuning.map((note, stringIndex) => {
+        const currentPitch = note.slice(0, -1);
+        const currentOctave = parseInt(note.slice(-1), 10);
+
+        return (
+          <div key={stringIndex} className="string-tuning-controls">
+            <span>String {stringIndex + 1}: </span>
+            <select
+              value={currentPitch}
+              onChange={(e) => handleNoteChange(stringIndex, e.target.value)}
+              aria-label={`String ${stringIndex + 1} note`}
+            >
+              {notes.map((pitchName) => (
+                <option key={pitchName} value={pitchName}>
+                  {pitchName}
+                </option>
+              ))}
+            </select>
+            <select
+              value={currentOctave}
+              onChange={(e) => handleOctaveChange(stringIndex, parseInt(e.target.value, 10))}
+              aria-label={`String ${stringIndex + 1} octave`}
+            >
+              {OCTAVE_RANGE.map((octaveValue) => (
+                <option key={octaveValue} value={octaveValue}>
+                  {octaveValue}
+                </option>
+              ))}
+            </select>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default Tuning;

--- a/src/com/Fretboard.js
+++ b/src/com/Fretboard.js
@@ -5,18 +5,18 @@ import {useGuitar} from '../guitarContext'
 
 export default function Fretboard({
   numberOfFrets=22,
-  strings=['e2', 'a2', 'd3', 'g3', 'b3', 'e3'],
+  // strings prop removed, will use tuning from context
 }) {
-  const [state] = useGuitar()
+  const { tuning } = useGuitar(); // Changed to get tuning from context
   
   const [startingNotes, setStartingNotes] = useState([])
   
   
   useEffect(() => {
-    if (strings?.map) {
-      setStartingNotes([...strings].reverse())
+    if (tuning?.map) { // Changed from strings to tuning
+      setStartingNotes([...tuning].reverse()) // Changed from strings to tuning
     }
-  }, [strings])
+  }, [tuning]) // Changed from strings to tuning
   
   
   return <>
@@ -29,6 +29,6 @@ export default function Fretboard({
       />
     )}
     
-    {/* <pre> {JSON.stringify(state, null, 2)} </pre> */}
+    {/* <pre> {JSON.stringify(tuning, null, 2)} </pre> {/* Optionally log tuning for debugging */}
   </>
 }

--- a/src/guitarContext.js
+++ b/src/guitarContext.js
@@ -1,21 +1,38 @@
-import {createContext, useContext, useState} from 'react'
-
+import {createContext, useContext, useState, useEffect} from 'react'
 
 const GuitarContext = createContext()
-
 
 export function useGuitar() {
   return useContext(GuitarContext)
 }
 
+const STANDARD_TUNING = ['e2', 'a2', 'd3', 'g3', 'b3', 'e3']
 
 export function GuitarProvider({children}) {
-  const state = useState({})
-  
-  return <GuitarContext.Provider value={state}>
+  const existingState = useState({}) // Renamed for clarity
+  const [tuning, setTuningState] = useState(() => {
+    const savedTuning = localStorage.getItem('guitarTuning')
+    return savedTuning ? JSON.parse(savedTuning) : STANDARD_TUNING
+  })
+
+  useEffect(() => {
+    localStorage.setItem('guitarTuning', JSON.stringify(tuning))
+  }, [tuning])
+
+  const setTuning = (newTuning) => {
+    setTuningState(newTuning)
+  }
+
+  const contextValue = {
+    guitarState: existingState[0],
+    setGuitarState: existingState[1],
+    tuning,
+    setTuning,
+  }
+
+  return <GuitarContext.Provider value={contextValue}>
     {children}
   </GuitarContext.Provider>
 }
-
 
 export default GuitarContext


### PR DESCRIPTION
This commit introduces a new tuning widget that allows you to change the root note for each string.

Key changes include:

1.  **Tuning Widget (`src/com/Controls/Tuning.js`):**
    *   New component with dropdown selectors for pitch class and octave for each string.
    *   Updates tuning via context.

2.  **Context Update (`src/guitarContext.js`):**
    *   Extended to manage `tuning` state.
    *   Initializes tuning from local storage (`guitarTuning`) or defaults to standard EADGBe tuning.
    *   Persists tuning changes to local storage automatically.
    *   Provides `tuning` state and `setTuning` updater through the context.

3.  **Integration:**
    *   `Tuning` widget added to `src/com/Controls/Main.js`.
    *   `Fretboard.js` now sources its string tuning directly from the `guitarContext`, removing the previous hardcoded prop and making it reactive to tuning changes.

This feature allows you to customize your instrument's tuning, and your preferences are saved across sessions using browser local storage.